### PR TITLE
Added connection info as a second parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ use astra::{Body, Response, Server};
 
 fn main() {
     Server::bind("localhost:3000")
-        .serve(|_req| Response::new(Body::new("Hello World!")))
+        .serve(|_req, _connection_info| Response::new(Body::new("Hello World!")))
         .expect("serve failed");
 }
 ```
@@ -26,7 +26,7 @@ use std::time::Duration;
 
 fn main() {
     Server::bind("localhost:3000")
-        .serve(|_req| {
+        .serve(|_req, _connection_info| {
             // Putting the worker thread to sleep will allow
             // other workers to run.
             std::thread::sleep(Duration::from_secs(1));

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ use astra::{Body, Response, Server};
 
 fn main() {
     Server::bind("localhost:3000")
-        .serve(|_req, _connection_info| Response::new(Body::new("Hello World!")))
+        .serve(|_req, _info| Response::new(Body::new("Hello World!")))
         .expect("serve failed");
 }
 ```
@@ -26,7 +26,7 @@ use std::time::Duration;
 
 fn main() {
     Server::bind("localhost:3000")
-        .serve(|_req, _connection_info| {
+        .serve(|_req, _info| {
             // Putting the worker thread to sleep will allow
             // other workers to run.
             std::thread::sleep(Duration::from_secs(1));

--- a/examples/connection_info.rs
+++ b/examples/connection_info.rs
@@ -1,0 +1,18 @@
+use astra::{Body, Request, Response, Server, ConnectionInfo};
+use std::sync::atomic::{Ordering};
+
+fn main() {
+
+    Server::bind("localhost:3000")
+        // connection_info is a second parameter like request
+        .serve(move |req, connection_info| handle(req, connection_info))
+        .expect("serve failed");
+}
+
+fn handle(_req: Request, connection_info: ConnectionInfo) -> Response {
+    // Get the ip address of the client
+    let peer_ip = connection_info.peer_addr.ip().to_string();
+    log::debug!("The clients ip is  {peer_ip}");
+
+    Response::new(Body::new(format!("Hello {}!", peer_ip)))
+}

--- a/examples/connection_info.rs
+++ b/examples/connection_info.rs
@@ -2,8 +2,7 @@ use astra::{Body, ConnectionInfo, Request, Response, Server};
 
 fn main() {
     Server::bind("localhost:3000")
-        // connection_info is a second parameter like request
-        .serve(move |req, info| handle(req, info))
+        .serve(handle)
         .expect("serve failed");
 }
 

--- a/examples/connection_info.rs
+++ b/examples/connection_info.rs
@@ -1,17 +1,22 @@
-use astra::{Body, Request, Response, Server, ConnectionInfo};
-use std::sync::atomic::{Ordering};
+use astra::{Body, ConnectionInfo, Request, Response, Server};
 
 fn main() {
-
     Server::bind("localhost:3000")
         // connection_info is a second parameter like request
-        .serve(move |req, connection_info| handle(req, connection_info))
+        .serve(move |req, info| handle(req, info))
         .expect("serve failed");
 }
 
-fn handle(_req: Request, connection_info: ConnectionInfo) -> Response {
+fn handle(_req: Request, info: ConnectionInfo) -> Response {
     // Get the ip address of the client
-    let peer_ip = connection_info.peer_addr.ip().to_string();
+    let peer_addr = match info.peer_addr {
+        Some(peer_add) => peer_add,
+        None => {
+            log::error!("Could not get the clients ip address");
+            return Response::new(Body::new("Internal Server Error"));
+        }
+    };
+    let peer_ip = peer_addr.ip().to_string();
     log::debug!("The clients ip is  {peer_ip}");
 
     Response::new(Body::new(format!("Hello {}!", peer_ip)))

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -2,6 +2,6 @@ use astra::{Body, Response, Server};
 
 fn main() {
     Server::bind("127.0.0.1:3000")
-        .serve(|_req, _connection_info| Response::new(Body::new("Hello World!")))
+        .serve(|_req, _info| Response::new(Body::new("Hello World!")))
         .expect("serve failed");
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -2,6 +2,6 @@ use astra::{Body, Response, Server};
 
 fn main() {
     Server::bind("127.0.0.1:3000")
-        .serve(|_req| Response::new(Body::new("Hello World!")))
+        .serve(|_req, _connection_info| Response::new(Body::new("Hello World!")))
         .expect("serve failed");
 }

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use astra::{Body, Request, Response, ResponseBuilder, Server, ConnectionInfo};
+use astra::{Body, Request, Response, ResponseBuilder, Server};
 use matchit::Match;
 
 type Router = matchit::Router<fn(Request) -> Response>;
@@ -34,12 +34,12 @@ fn main() {
 
     Server::bind("localhost:3000")
         // Pass the router to `route`, along with the request
-        .serve(move |req, _| route(router.clone(), req))
+        .serve(move |req, _info| route(router.clone(), req))
         .expect("serve failed");
 }
 
 fn route(router: Arc<Router>, mut req: Request) -> Response {
-    // Try to find the handler for the requested path`
+    // Try to find the handler for the requested path
     match router.at(req.uri().path()) {
         // If a handler is found, insert the route parameters into the request
         // extensions, and call it

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use astra::{Body, Request, Response, ResponseBuilder, Server};
+use astra::{Body, Request, Response, ResponseBuilder, Server, ConnectionInfo};
 use matchit::Match;
 
 type Router = matchit::Router<fn(Request) -> Response>;
@@ -34,12 +34,12 @@ fn main() {
 
     Server::bind("localhost:3000")
         // Pass the router to `route`, along with the request
-        .serve(move |req| route(router.clone(), req))
+        .serve(move |req, _| route(router.clone(), req))
         .expect("serve failed");
 }
 
 fn route(router: Arc<Router>, mut req: Request) -> Response {
-    // Try to find the handler for the requested path
+    // Try to find the handler for the requested path`
     match router.at(req.uri().path()) {
         // If a handler is found, insert the route parameters into the request
         // extensions, and call it

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -7,7 +7,7 @@ fn main() {
 
     Server::bind("localhost:3000")
         // Pass a handle to the counter along with the request
-        .serve(move |req| handle(counter.clone(), req))
+        .serve(move |req, _| handle(counter.clone(), req))
         .expect("serve failed");
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ mod server;
 
 pub use http::{Body, Request, Response, ResponseBuilder};
 pub use server::{Server, Service};
+pub use net::ConnectionInfo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,4 @@ mod net;
 mod server;
 
 pub use http::{Body, Request, Response, ResponseBuilder};
-pub use server::{Server, Service};
-pub use net::ConnectionInfo;
+pub use server::{ConnectionInfo, Server, Service};

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
-use std::net::{self as sys, Shutdown};
+use std::net::{self as sys, Shutdown, SocketAddr};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -42,7 +42,12 @@ impl Reactor {
     pub fn register(&self, sys: sys::TcpStream) -> io::Result<TcpStream> {
         sys.set_nonblocking(true)?;
         let mut sys = mio::net::TcpStream::from_std(sys);
-
+        let local_addr = sys.local_addr().unwrap();
+        let peer_addr = sys.peer_addr().unwrap();
+        let connection_info = ConnectionInfo {
+            local_addr,
+            peer_addr
+        };
         let token = Token(self.shared.token.fetch_add(1, Ordering::Relaxed));
 
         self.shared.registry.register(
@@ -66,6 +71,7 @@ impl Reactor {
             sys,
             source,
             reactor: self.clone(),
+            connection_info
         })
     }
 
@@ -179,10 +185,17 @@ struct Source {
     token: Token,
 }
 
+#[derive(Clone)]
+pub struct ConnectionInfo {
+    pub peer_addr: SocketAddr,
+    pub local_addr: SocketAddr
+}
+
 pub struct TcpStream {
     sys: mio::net::TcpStream,
     reactor: Reactor,
     source: Arc<Source>,
+    pub connection_info: ConnectionInfo
 }
 
 impl TcpStream {


### PR DESCRIPTION
This is to resolve #2 .  I implemented it as best as possible, following the issue's details. There is now a second parameter that passes along with the request. It is connection_info, which holds info I got from the TcpSocket connection, like the request IP. I am still learning Rust, so please let me know if there is something I need to do differently. I was wondering if I should be unwrapping the local_addr or peer_addr like I am. Also, with the way I passed the new struct connection info from the reactor. 