### PR TITLE
add Server::local_addr

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -72,7 +72,7 @@ impl Reactor {
         &self,
         source: &Source,
         direction: usize,
-        cx: &mut Context<'_>,
+        cx: &Context<'_>,
     ) -> Poll<io::Result<()>> {
         if source.triggered[direction].load(Ordering::Acquire) {
             return Poll::Ready(Ok(()));
@@ -189,7 +189,7 @@ impl TcpStream {
         &self,
         direction: usize,
         mut f: impl FnMut() -> io::Result<T>,
-        cx: &mut Context<'_>,
+        cx: &Context<'_>,
     ) -> Poll<io::Result<T>> {
         loop {
             if self

--- a/src/server.rs
+++ b/src/server.rs
@@ -368,6 +368,15 @@ impl Server {
         self
     }
 
+    /// Get the local address of the bound socket
+    pub fn local_addr(&self) -> Option<io::Result<SocketAddr>> {
+        let listener = self.listener.as_ref()?;
+        let addr = listener
+            .local_addr()
+            .map_err(|_e| io::Error::new(io::ErrorKind::Other, "Server::bind not called yet"));
+        Some(addr)
+    }
+
     fn configure<T>(&self, http: &mut Http<T>) {
         macro_rules! configure {
             ($self:ident, $other:expr, [$($option:ident),* $(,)?], [$($other_option:ident => $this_option:ident),* $(,)?]) => {{


### PR DESCRIPTION
Useful for figuring the actual port if the `:0` was used to auto-assign it.